### PR TITLE
feat: add whitelist support

### DIFF
--- a/src/whitelist.lua
+++ b/src/whitelist.lua
@@ -1,0 +1,46 @@
+local M = {}
+
+local json
+local ok, j = pcall(require, 'dkjson')
+if ok then
+    json = j
+else
+    ok, j = pcall(require, 'cjson')
+    if ok then
+        json = j
+    else
+        error('No JSON library found')
+    end
+end
+
+local cache
+
+function M.load_whitelist()
+    if cache then
+        return cache
+    end
+
+    local file = io.open('whitelist.json', 'r')
+    if not file then
+        cache = {}
+        return cache
+    end
+
+    local data = file:read('*a')
+    file:close()
+    cache = json.decode(data)
+    return cache
+end
+
+function M.is_allowed(pkg)
+    local wl = M.load_whitelist()
+    return wl[pkg] ~= nil
+end
+
+function M.update_whitelist()
+    -- Placeholder for future synchronization with a central repository
+    -- TODO: implement remote whitelist update logic
+    return nil, 'not implemented'
+end
+
+return M

--- a/whitelist.json
+++ b/whitelist.json
@@ -1,0 +1,10 @@
+{
+  "example-package": {
+    "version": "1.0.0",
+    "description": "Sample package allowed in whitelist"
+  },
+  "another-package": {
+    "version": "2.1.3",
+    "description": "Another allowed package"
+  }
+}


### PR DESCRIPTION
## Summary
- add root whitelist.json with sample packages
- implement whitelist module with loader, checker, and update stub

## Testing
- `luac -p src/main.lua src/whitelist.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a5bb9fc164832087ef1fbba861b276