### PR TITLE
feat: add YAML config module

### DIFF
--- a/src/config.lua
+++ b/src/config.lua
@@ -1,0 +1,51 @@
+local yaml = require 'lyaml'
+
+local M = {}
+
+local home = os.getenv('HOME') or '.'
+local config_dir = home .. '/.yelua'
+local config_path = config_dir .. '/config.yaml'
+
+local default_config = {
+    cache_dir = home .. '/.cache/yelua'
+}
+
+local function ensure_dir(path)
+    os.execute(string.format('mkdir -p %q', path))
+end
+
+function M.save(cfg)
+    ensure_dir(config_dir)
+    local file = assert(io.open(config_path, 'w'))
+    file:write(yaml.dump({cfg}))
+    file:close()
+end
+
+function M.load()
+    ensure_dir(config_dir)
+    local file = io.open(config_path, 'r')
+    if file then
+        local content = file:read('*a')
+        file:close()
+        local ok, cfg = pcall(yaml.load, content)
+        if ok and type(cfg) == 'table' then
+            for k, v in pairs(default_config) do
+                if cfg[k] == nil then
+                    cfg[k] = v
+                end
+            end
+            return cfg
+        end
+    end
+    local cfg = {}
+    for k, v in pairs(default_config) do
+        cfg[k] = v
+    end
+    M.save(cfg)
+    return cfg
+end
+
+M.path = config_path
+
+return M
+

--- a/src/main.lua
+++ b/src/main.lua
@@ -1,6 +1,9 @@
 local argparse = require 'argparse'
+local config = require 'config'
 
 local function main(input_args)
+    local cfg = config.load()
+
     local parser = argparse('yelua', 'Yelua package manager')
     parser:command('install', 'Install packages')
     parser:command('remove', 'Remove packages')


### PR DESCRIPTION
## Summary
- add config module to manage YAML configuration and defaults
- load configuration at startup

## Testing
- `rm -rf ~/.yelua && ./yelua`


------
https://chatgpt.com/codex/tasks/task_b_68a5bba956648320a24e0a107fc84a96