### PR TITLE
feat: add package management commands

### DIFF
--- a/src/list.lua
+++ b/src/list.lua
@@ -1,0 +1,49 @@
+local json
+local ok, j = pcall(require, 'dkjson')
+if ok then
+    json = j
+else
+    ok, j = pcall(require, 'cjson')
+    if ok then
+        json = j
+    else
+        error('No JSON library found')
+    end
+end
+
+local config = require 'config'
+local whitelist = require 'whitelist'
+local cfg = config.load()
+
+local function read_lock(path)
+    local file = io.open(path, 'r')
+    if file then
+        local data = file:read('*a')
+        file:close()
+        local ok, t = pcall(json.decode, data)
+        if ok and type(t) == 'table' then
+            return t
+        end
+    end
+    return {}
+end
+
+local function dir_exists(path)
+    local ok = os.execute(string.format('[ -d %q ]', path))
+    return ok == true or ok == 0
+end
+
+return function()
+    local lock = read_lock('./yelua.lock')
+    if next(lock) == nil then
+        print('No packages installed')
+        return
+    end
+    for pkg, info in pairs(lock) do
+        local allowed = whitelist.is_allowed(pkg) and 'yes' or 'no'
+        local cache_path = string.format('%s/%s/%s', cfg.cache_dir, pkg, info.version or 'latest')
+        local cached = dir_exists(cache_path) and 'yes' or 'no'
+        print(string.format('%s %s (whitelist: %s, cached: %s)', pkg, info.version or '', allowed, cached))
+    end
+end
+

--- a/src/main.lua
+++ b/src/main.lua
@@ -5,17 +5,41 @@ local function main(input_args)
     local cfg = config.load()
 
     local parser = argparse('yelua', 'Yelua package manager')
-    parser:command('install', 'Install packages')
-    parser:command('remove', 'Remove packages')
+
+    local install = parser:command('install', 'Install packages')
+    install:argument('package', 'Packages to install'):args('+')
+
+    local remove = parser:command('remove', 'Remove packages')
+    remove:argument('package', 'Packages to remove'):args('+')
+
+    local update = parser:command('update', 'Update packages')
+    update:argument('package', 'Packages to update'):args('*')
+
+    parser:command('list', 'List installed packages')
+
+    local search = parser:command('search', 'Search whitelist')
+    search:argument('term', 'Search term')
+
     local cache = parser:command('cache', 'Cache operations')
     cache:command('clean', 'Purge cache')
+
     local args = parser:parse(input_args)
 
     if args.install then
         print('Installing packages...')
     elseif args.remove then
-        print('Removing packages...')
-    elseif args.cache and args.clean then
+        local cmd = require 'remove'
+        cmd(args)
+    elseif args.update then
+        local cmd = require 'update'
+        cmd(args)
+    elseif args.list then
+        local cmd = require 'list'
+        cmd()
+    elseif args.search then
+        local cmd = require 'search'
+        cmd(args)
+    elseif args.cache and args.cache.clean then
         os.execute(string.format('rm -rf %q', cfg.cache_dir))
         print('Cache cleaned')
     else

--- a/src/remove.lua
+++ b/src/remove.lua
@@ -1,0 +1,75 @@
+local json
+local ok, j = pcall(require, 'dkjson')
+if ok then
+    json = j
+else
+    ok, j = pcall(require, 'cjson')
+    if ok then
+        json = j
+    else
+        error('No JSON library found')
+    end
+end
+
+local config = require 'config'
+local whitelist = require 'whitelist'
+local cfg = config.load()
+
+local function json_encode(tbl)
+    local ok, res = pcall(json.encode, tbl, { indent = true })
+    if ok then
+        return res
+    end
+    ok, res = pcall(json.encode, tbl)
+    if ok then
+        return res
+    end
+    error('Failed to encode JSON')
+end
+
+local function read_lock(path)
+    local file = io.open(path, 'r')
+    if file then
+        local data = file:read('*a')
+        file:close()
+        local ok, t = pcall(json.decode, data)
+        if ok and type(t) == 'table' then
+            return t
+        end
+    end
+    return {}
+end
+
+local function write_lock(path, tbl)
+    local file = assert(io.open(path, 'w'))
+    file:write(json_encode(tbl))
+    file:close()
+end
+
+local function dir_exists(path)
+    local ok = os.execute(string.format('[ -d %q ]', path))
+    return ok == true or ok == 0
+end
+
+return function(args)
+    local lock_path = './yelua.lock'
+    local lock = read_lock(lock_path)
+    for _, pkg in ipairs(args.package or {}) do
+        if whitelist.is_allowed(pkg) then
+            local mod_path = string.format('./lua_modules/%s', pkg)
+            if dir_exists(mod_path) then
+                os.execute(string.format('rm -rf %q', mod_path))
+            end
+            lock[pkg] = nil
+            local cache_path = string.format('%s/%s', cfg.cache_dir, pkg)
+            if dir_exists(cache_path) then
+                os.execute(string.format('rm -rf %q', cache_path))
+            end
+            print(string.format('Removed %s', pkg))
+        else
+            print(string.format('Package %s is not permitted by whitelist', pkg))
+        end
+    end
+    write_lock(lock_path, lock)
+end
+

--- a/src/search.lua
+++ b/src/search.lua
@@ -1,0 +1,22 @@
+local config = require 'config'
+local whitelist = require 'whitelist'
+local cfg = config.load()
+
+local function dir_exists(path)
+    local ok = os.execute(string.format('[ -d %q ]', path))
+    return ok == true or ok == 0
+end
+
+return function(args)
+    local term = args.term and args.term:lower() or ''
+    local wl = whitelist.load_whitelist()
+    for pkg, info in pairs(wl) do
+        if pkg:lower():find(term, 1, true) then
+            local cache_path = string.format('%s/%s', cfg.cache_dir, pkg)
+            local cached = dir_exists(cache_path) and 'yes' or 'no'
+            local desc = info.description or ''
+            print(string.format('%s - %s (cached: %s)', pkg, desc, cached))
+        end
+    end
+end
+

--- a/src/update.lua
+++ b/src/update.lua
@@ -1,0 +1,73 @@
+local json
+local ok, j = pcall(require, 'dkjson')
+if ok then
+    json = j
+else
+    ok, j = pcall(require, 'cjson')
+    if ok then
+        json = j
+    else
+        error('No JSON library found')
+    end
+end
+
+local config = require 'config'
+local whitelist = require 'whitelist'
+local git = require 'git'
+local cfg = config.load()
+
+local function read_lock(path)
+    local file = io.open(path, 'r')
+    if file then
+        local data = file:read('*a')
+        file:close()
+        local ok, t = pcall(json.decode, data)
+        if ok and type(t) == 'table' then
+            return t
+        end
+    end
+    return {}
+end
+
+local function dir_exists(path)
+    local ok = os.execute(string.format('[ -d %q ]', path))
+    return ok == true or ok == 0
+end
+
+return function(args)
+    local lock_path = './yelua.lock'
+    local lock = read_lock(lock_path)
+    local targets = {}
+    if args.package and #args.package > 0 then
+        for _, p in ipairs(args.package) do
+            if lock[p] then
+                table.insert(targets, p)
+            else
+                print(string.format('Package %s not installed', p))
+            end
+        end
+    else
+        for p, _ in pairs(lock) do
+            table.insert(targets, p)
+        end
+    end
+
+    for _, pkg in ipairs(targets) do
+        if whitelist.is_allowed(pkg) then
+            local info = lock[pkg]
+            local cache_path = string.format('%s/%s', cfg.cache_dir, pkg)
+            if dir_exists(cache_path) then
+                os.execute(string.format('rm -rf %q', cache_path))
+            end
+            local ok, err = git.install(pkg, info.source, nil, '.')
+            if ok then
+                print(string.format('Updated %s', pkg))
+            else
+                print(string.format('Failed to update %s: %s', pkg, err))
+            end
+        else
+            print(string.format('Package %s is not permitted by whitelist', pkg))
+        end
+    end
+end
+


### PR DESCRIPTION
## Summary
- extend CLI parser with remove, update, list and search subcommands
- implement package operations and integrate whitelist & cache handling

## Testing
- `luac -p src/main.lua src/remove.lua src/update.lua src/list.lua src/search.lua`
- `./yelua --help`
- `./yelua search example`
- `./yelua list`


------
https://chatgpt.com/codex/tasks/task_b_68a5c31179f48320a46fdb5b80a9570c