### PR TITLE
docs: add usage guides and packaging setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+.RECIPEPREFIX = >
+.PHONY: build rock test
+
+build:
+>luastatic yelua src/*.lua -o yelua.bin
+
+rock:
+>luarocks make
+
+test:
+>busted tests

--- a/README.md
+++ b/README.md
@@ -1,0 +1,77 @@
+# Yelua
+
+Yelua is a minimal package manager written in Lua.
+
+## Installation
+
+### Prerequisites
+
+- Lua 5.1+
+- Git
+- [LuaRocks](https://luarocks.org/) for dependency management
+
+### From source
+
+```sh
+git clone https://github.com/Loles25/yelua.git
+cd yelua
+luarocks install --deps-only yelua-0.1-1.rockspec
+```
+
+### Building a binary
+
+A standalone binary can be produced with [luastatic](https://github.com/ers35/luastatic):
+
+```sh
+make build
+./yelua.bin list
+```
+
+### LuaRocks packaging
+
+To install locally through LuaRocks:
+
+```sh
+luarocks make
+```
+
+## Commands
+
+- `install <package>`: install one or more packages.
+- `remove <package>`: remove installed packages.
+- `update [package]`: update all packages or only the ones listed.
+- `list`: display installed packages.
+- `search <term>`: search the whitelist.
+- `cache clean`: purge the cache.
+
+## Configuration
+
+The main configuration file is located at `~/.yelua/config.yaml`:
+
+```yaml
+cache_dir: ~/.yelua/cache
+```
+
+## `yelua.json` file
+
+A project can declare its dependencies in a root `yelua.json` file:
+
+```json
+{
+  "dependencies": {
+    "example-package": "1.0.0",
+    "another-package": "*"
+  }
+}
+```
+
+Then run:
+
+```sh
+./yelua install
+```
+
+## Documentation
+
+More detailed information is available in the [`docs/`](docs/) folder.
+

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,31 @@
+# Configuration
+
+Yelua stores its configuration in `~/.yelua/config.yaml`.
+
+## Example
+
+```yaml
+cache_dir: ~/.yelua/cache
+```
+
+The directory is created automatically on first run.
+
+## Declare dependencies with `yelua.json`
+
+Place a `yelua.json` file at the project root to list required packages:
+
+```json
+{
+  "dependencies": {
+    "example-package": "1.0.0",
+    "another-package": "*"
+  }
+}
+```
+
+Then run `./yelua install` to fetch the dependencies.
+
+## Whitelist
+
+Installable packages are defined in `whitelist.json`. Only packages listed there can be installed.
+

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -1,0 +1,25 @@
+# Distribution
+
+## Generating a binary
+
+Yelua can be packaged as a binary using [`luastatic`](https://github.com/ers35/luastatic).
+
+```sh
+make build
+./yelua.bin list
+```
+
+## Publishing on LuaRocks
+
+A rockspec (`yelua-0.1-1.rockspec`) is provided. To install locally:
+
+```sh
+luarocks make
+```
+
+To publish on LuaRocks:
+
+```sh
+luarocks upload yelua-0.1-1.rockspec --api-key=<key>
+```
+

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,41 @@
+# Usage
+
+This document presents the main **Yelua** commands with examples.
+
+## Install packages
+
+```sh
+./yelua install mypkg otherpkg
+```
+
+## Remove packages
+
+```sh
+./yelua remove mypkg
+```
+
+## Update
+
+```sh
+./yelua update            # updates all packages
+./yelua update mypkg      # updates only mypkg
+```
+
+## List packages
+
+```sh
+./yelua list
+```
+
+## Search the whitelist
+
+```sh
+./yelua search yaml
+```
+
+## Clean the cache
+
+```sh
+./yelua cache clean
+```
+

--- a/yelua-0.1-1.rockspec
+++ b/yelua-0.1-1.rockspec
@@ -1,0 +1,33 @@
+package = "yelua"
+version = "0.1-1"
+source = {
+   url = "git+https://github.com/Loles25/yelua"
+}
+description = {
+   summary = "Yelua package manager",
+   detailed = [[Simple package manager written in Lua.]],
+   license = "MIT",
+   homepage = "https://github.com/Loles25/yelua"
+}
+dependencies = {
+   "lua >= 5.1",
+   "argparse",
+   "lyaml",
+   "dkjson"
+}
+build = {
+   type = "builtin",
+   modules = {
+      ["main"] = "src/main.lua",
+      ["config"] = "src/config.lua",
+      ["git"] = "src/git.lua",
+      ["list"] = "src/list.lua",
+      ["remove"] = "src/remove.lua",
+      ["search"] = "src/search.lua",
+      ["update"] = "src/update.lua",
+      ["whitelist"] = "src/whitelist.lua"
+   },
+   install = {
+      bin = { yelua = "yelua" }
+   }
+}

--- a/yelua.json
+++ b/yelua.json
@@ -1,1 +1,6 @@
-
+{
+  "dependencies": {
+    "example-package": "1.0.0",
+    "another-package": "*"
+  }
+}


### PR DESCRIPTION
## Summary
- add project README with install, commands and config info
- document usage, configuration and packaging in new docs/
- provide sample `yelua.json` plus Makefile and rockspec for binary builds and LuaRocks
- translate README, docs and rockspec to English referencing `Loles25`

## Testing
- `busted tests`


------
https://chatgpt.com/codex/tasks/task_b_68a5ccfe0a2c832091d98d5b3d9b2490