### PR TITLE
chore: add popular Lua packages to whitelist

### DIFF
--- a/whitelist.json
+++ b/whitelist.json
@@ -6,5 +6,53 @@
   "another-package": {
     "version": "2.1.3",
     "description": "Another allowed package"
+  },
+  "luasocket": {
+    "version": "*",
+    "description": "TCP/UDP, HTTP, SMTP support"
+  },
+  "luasec": {
+    "version": "*",
+    "description": "TLS/SSL support for LuaSocket"
+  },
+  "luafilesystem": {
+    "version": "*",
+    "description": "Filesystem manipulation library"
+  },
+  "penlight": {
+    "version": "*",
+    "description": "Utility libraries 'batteries included'"
+  },
+  "cjson": {
+    "version": "*",
+    "description": "High-performance JSON encoder/decoder"
+  },
+  "lpeg": {
+    "version": "*",
+    "description": "Parsing Expression Grammars for Lua"
+  },
+  "mpack": {
+    "version": "*",
+    "description": "MessagePack encoding/decoding"
+  },
+  "moses": {
+    "version": "*",
+    "description": "Utility functions à la Lodash/Underscore"
+  },
+  "busted": {
+    "version": "*",
+    "description": "Unit testing framework for Lua"
+  },
+  "luacheck": {
+    "version": "*",
+    "description": "Static analyzer and linter for Lua"
+  },
+  "lapis": {
+    "version": "*",
+    "description": "Web framework for OpenResty/Nginx"
+  },
+  "moonscript": {
+    "version": "*",
+    "description": "Language that compiles to Lua"
   }
 }


### PR DESCRIPTION
## Summary
- add common Lua libraries like luasocket, luasec, penlight, and more to whitelist

## Testing
- `make test` *(fails: busted: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68a5ba37c8488320ba2372138b3a3f51